### PR TITLE
Fix Bugsnag error context leaking between Sidekiq jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.2'
+          - '3.2.0'
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 inherit_from: https://raw.githubusercontent.com/idea-fragments/rubocop-config/main/.rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-29
+
+### Fixed
+- ErrorContextSetter::BugsnagAdapter no longer registers a new `add_on_error` callback per invocation, which caused stale metadata from previous jobs to leak onto unrelated error reports in multi-threaded Sidekiq processes
+- Bugsnag error context metadata is now stored in thread-local storage, ensuring isolation between concurrent Sidekiq threads
+
+### Added
+- SidekiqErrorContextMiddleware to clear thread-local error context after each job completes
+- Global `add_on_error` callback registered once at boot via `config_bugsnag`, reading context from thread-local storage
+
 ## [0.2.2] - 2026-03-03
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    idea_fragments_system_observability (0.2.2)
+    idea_fragments_system_observability (0.3.0)
       activesupport (~> 8.0.2)
       bugsnag (~> 6.27)
       dogstatsd-ruby (~> 5.6)

--- a/lib/system_observability/configuration.rb
+++ b/lib/system_observability/configuration.rb
@@ -13,6 +13,14 @@ class SystemObservability::Configuration
       config.app_version = app_version
       config.enabled_release_stages = enabled_envs
     end
+
+    Bugsnag.add_on_error(method(:add_error_context_from_thread))
+
+    Sidekiq.configure_server do |config|
+      config.server_middleware do |chain|
+        chain.add SystemObservability::SidekiqErrorContextMiddleware
+      end
+    end
   end
 
   def config_datadog(
@@ -48,6 +56,13 @@ class SystemObservability::Configuration
   end
 
   private
+
+  def add_error_context_from_thread(report)
+    metadata = Thread.current[SystemObservability::ErrorContextSetter::BugsnagAdapter::THREAD_KEY]
+    return unless metadata
+
+    report.add_metadata(:context, metadata)
+  end
 
   def config_sidekiq_stats_middleware
     Sidekiq.configure_server do |config|

--- a/lib/system_observability/configuration.rb
+++ b/lib/system_observability/configuration.rb
@@ -39,12 +39,12 @@ class SystemObservability::Configuration
 
   def config_error_reporter(provider:)
     self.error_reporter_adapter = case provider
-    when :bugsnag
-      SystemObservability::ErrorReporter::BugsnagAdapter
-    when :sentry
-      SystemObservability::ErrorReporter::SentryAdapter
-    else
-      raise ArgumentError, "Unknown error reporter provider: #{provider}"
+      when :bugsnag
+        SystemObservability::ErrorReporter::BugsnagAdapter
+      when :sentry
+        SystemObservability::ErrorReporter::SentryAdapter
+      else
+        raise ArgumentError, "Unknown error reporter provider: #{provider}"
     end
   end
 

--- a/lib/system_observability/error_context_setter.rb
+++ b/lib/system_observability/error_context_setter.rb
@@ -26,12 +26,13 @@ class SystemObservability::ErrorContextSetter
 
   def adapter_class
     case SystemObservability.configuration.error_reporter_adapter.name
-    when "SystemObservability::ErrorReporter::BugsnagAdapter"
-      SystemObservability::ErrorContextSetter::BugsnagAdapter
-    when "SystemObservability::ErrorReporter::SentryAdapter"
-      SystemObservability::ErrorContextSetter::SentryAdapter
-    else
-      raise ArgumentError, "Unknown error reporter adapter: #{SystemObservability.configuration.error_reporter_adapter}"
+      when "SystemObservability::ErrorReporter::BugsnagAdapter"
+        SystemObservability::ErrorContextSetter::BugsnagAdapter
+      when "SystemObservability::ErrorReporter::SentryAdapter"
+        SystemObservability::ErrorContextSetter::SentryAdapter
+      else
+        raise ArgumentError,
+          "Unknown error reporter adapter: #{SystemObservability.configuration.error_reporter_adapter}"
     end
   end
 

--- a/lib/system_observability/error_context_setter/bugsnag_adapter.rb
+++ b/lib/system_observability/error_context_setter/bugsnag_adapter.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
 class SystemObservability::ErrorContextSetter::BugsnagAdapter
+  THREAD_KEY = :__system_observability_error_context
+
   def self.call(metadata:)
     new(metadata:).call
   end
 
+  def self.clear
+    Thread.current[THREAD_KEY] = nil
+  end
+
   def call
-    Bugsnag.add_on_error(method(:add_report_context))
+    Thread.current[THREAD_KEY] = formatted_metadata
   end
 
   private
 
   attr_accessor :metadata
-
-  def add_report_context(report)
-    report.add_metadata(:context, formatted_metadata)
-  end
 
   def format_value(object)
     return object if SystemObservability::ErrorContextSetter::TYPES_WITHOUT_FORMATTERS.include?(object.class.name)

--- a/lib/system_observability/error_reporter.rb
+++ b/lib/system_observability/error_reporter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SystemObservability::ErrorReporter < SystemObservability::Service
-  def self.call(context: nil, error:, metadata: {}, severity: nil, user: nil)
+  def self.call(error:, context: nil, metadata: {}, severity: nil, user: nil)
     new(context:, error:, metadata:, severity:, user:).call
   end
 

--- a/lib/system_observability/error_reporter/sentry_adapter.rb
+++ b/lib/system_observability/error_reporter/sentry_adapter.rb
@@ -15,17 +15,19 @@ class SystemObservability::ErrorReporter::SentryAdapter
   end
 
   def call
-    Sentry.capture_exception(error) do |scope|
-      scope.set_context(:additional, { context: }) if context
-      scope.set_context(:custom, format_metadata(metadata)) if metadata.any?
-      scope.set_level(map_severity(severity)) if severity
-      scope.set_user(format_user(user)) if user
-    end
+    Sentry.capture_exception(error) { |scope| configure_scope(scope) }
   end
 
   private
 
   attr_accessor :context, :error, :metadata, :severity, :user
+
+  def configure_scope(scope)
+    scope.set_context(:additional, { context: }) if context
+    scope.set_context(:custom, format_metadata(metadata)) if metadata.any?
+    scope.set_level(map_severity(severity)) if severity
+    scope.set_user(format_user(user)) if user
+  end
 
   def format_metadata(metadata)
     metadata.each_with_object({}) do |(name, object), hash|

--- a/lib/system_observability/rails/web_error_reporter.rb
+++ b/lib/system_observability/rails/web_error_reporter.rb
@@ -5,12 +5,13 @@ module SystemObservability::Rails::WebErrorReporter
 
   included do
     case SystemObservability.configuration.error_reporter_adapter.name
-    when "SystemObservability::ErrorReporter::BugsnagAdapter"
-      include SystemObservability::Rails::WebErrorReporter::BugsnagAdapter
-    when "SystemObservability::ErrorReporter::SentryAdapter"
-      include SystemObservability::Rails::WebErrorReporter::SentryAdapter
-    else
-      raise ArgumentError, "Unknown error reporter adapter: #{SystemObservability.configuration.error_reporter_adapter}"
+      when "SystemObservability::ErrorReporter::BugsnagAdapter"
+        include SystemObservability::Rails::WebErrorReporter::BugsnagAdapter
+      when "SystemObservability::ErrorReporter::SentryAdapter"
+        include SystemObservability::Rails::WebErrorReporter::SentryAdapter
+      else
+        raise ArgumentError,
+          "Unknown error reporter adapter: #{SystemObservability.configuration.error_reporter_adapter}"
     end
   end
 end

--- a/lib/system_observability/sidekiq_error_context_middleware.rb
+++ b/lib/system_observability/sidekiq_error_context_middleware.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SystemObservability::SidekiqErrorContextMiddleware
+  include Sidekiq::ServerMiddleware
+
+  def call(_worker, _msg, _queue)
+    yield
+  ensure
+    SystemObservability::ErrorContextSetter::BugsnagAdapter.clear
+  end
+end

--- a/lib/system_observability/version.rb
+++ b/lib/system_observability/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SystemObservability
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/spec/lib/system_observability/error_context_setter_spec.rb
+++ b/spec/lib/system_observability/error_context_setter_spec.rb
@@ -1,26 +1,54 @@
 RSpec.describe SystemObservability::ErrorContextSetter do
-  let(:expect_context_added) do
-    ->(ctx) do
-      call_made = false
-      Bugsnag.add_on_error(
-        ->(report) do
-          expect(report.metadata).to include({ context: ctx })
-          call_made = true
-        end
-      )
-
-      Bugsnag.notify(StandardError.new("Test error"))
-      expect(call_made).to be true
-    end
-  end
   let(:metadata) { { my: "object" } }
+  let(:thread_key) { SystemObservability::ErrorContextSetter::BugsnagAdapter::THREAD_KEY }
+
+  after { SystemObservability::ErrorContextSetter::BugsnagAdapter.clear }
+
+  it "Stores metadata on the current thread" do
+    described_class.call(**metadata)
+    expect(Thread.current[thread_key]).to eq(metadata)
+  end
 
   it "Sends provided context to Bugsnag when an error occurs" do
     described_class.call(**metadata)
-    expect_context_added.call(metadata)
+
+    captured_metadata = nil
+    Bugsnag.add_on_error(lambda do |report|
+      captured_metadata = report.metadata[:context]
+    end)
+
+    Bugsnag.notify(StandardError.new("Test error"))
+
+    expect(captured_metadata).to eq(metadata)
   end
 
-  context "If an object is mapped to a context key" do
+  it "Does not leak metadata to other threads" do
+    described_class.call(receipt_id: "thread-1-receipt")
+
+    other_thread_metadata = nil
+    thread = Thread.new do
+      other_thread_metadata = Thread.current[thread_key]
+    end
+    thread.join
+
+    expect(other_thread_metadata).to be_nil
+  end
+
+  it "Does not leak metadata between sequential jobs on the same thread" do
+    described_class.call(receipt_id: "job-1-receipt")
+    SystemObservability::ErrorContextSetter::BugsnagAdapter.clear
+
+    captured_metadata = nil
+    Bugsnag.add_on_error(lambda do |report|
+      captured_metadata = report.metadata[:context]
+    end)
+
+    Bugsnag.notify(StandardError.new("Job 2 crash"))
+
+    expect(captured_metadata).to be_nil
+  end
+
+  context "When an object is mapped to a context key" do
     let(:team) { Team.new(id: (1..10).to_a.sample, name: Faker::Company.name) }
     let(:team_formatter) { ->(t) { t.to_h.slice(:id, :name) } }
     let(:user) do
@@ -44,7 +72,15 @@ RSpec.describe SystemObservability::ErrorContextSetter do
       expect(user_formatter).to receive(:call).with(user).and_call_original
 
       described_class.call(**metadata, team: team, user: user)
-      expect_context_added.call({
+
+      captured_metadata = nil
+      Bugsnag.add_on_error(lambda do |report|
+        captured_metadata = report.metadata[:context]
+      end)
+
+      Bugsnag.notify(StandardError.new("Test error"))
+
+      expect(captured_metadata).to eq({
         **metadata,
         team: team.to_h.slice(:id, :name),
         user: user.to_h.slice(:id, :first_name)

--- a/spec/lib/system_observability/sidekiq_error_context_middleware_spec.rb
+++ b/spec/lib/system_observability/sidekiq_error_context_middleware_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe SystemObservability::SidekiqErrorContextMiddleware do
+  let(:middleware) { described_class.new }
+  let(:thread_key) { SystemObservability::ErrorContextSetter::BugsnagAdapter::THREAD_KEY }
+
+  after { SystemObservability::ErrorContextSetter::BugsnagAdapter.clear }
+
+  it "Yields to the job block" do
+    expect do |probe|
+      middleware.call(double, {}, "default", &probe)
+    end.to yield_control
+  end
+
+  it "Clears error context after a successful job" do
+    SystemObservability::ErrorContextSetter.call(receipt_id: "abc-123")
+
+    middleware.call(double, {}, "default") {}
+
+    expect(Thread.current[thread_key]).to be_nil
+  end
+
+  it "Clears error context after a job that raises" do
+    SystemObservability::ErrorContextSetter.call(receipt_id: "abc-123")
+
+    expect do
+      middleware.call(double, {}, "default") { raise StandardError, "job failed" }
+    end.to raise_error(StandardError, "job failed")
+
+    expect(Thread.current[thread_key]).to be_nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.before { Bugsnag.add_on_error(->(report) { report.ignore! }) }
+  config.before { Bugsnag.add_on_error(lambda(&:ignore!)) }
 
   SystemObservability.configure do |c|
     c.config_bugsnag(


### PR DESCRIPTION
ErrorContextSetter::BugsnagAdapter was registering a new add_on_error callback on every invocation, causing stale metadata from previous jobs to accumulate and attach to unrelated error reports. This switches to thread-local storage for metadata isolation and registers a single global callback at boot that reads from Thread.current. A new Sidekiq server middleware clears the thread-local after each job completes.